### PR TITLE
Use standard spacing before a parameter

### DIFF
--- a/Lingo/SwiftGenerator.swift
+++ b/Lingo/SwiftGenerator.swift
@@ -54,7 +54,7 @@ struct SwiftGenerator {
             if let value = keyValues[nsLocalizedKey] {
                 swift += "\n        /// \(value)"
             }
-            swift += "\n        static let \(lowercasedKey) = NSLocalizedString(\"\(nsLocalizedKey)\", bundle: BundleLocator.bundle, comment:\"\")"
+            swift += "\n        static let \(lowercasedKey) = NSLocalizedString(\"\(nsLocalizedKey)\", bundle: BundleLocator.bundle, comment: \"\")"
         }
         swift += "\n    }"
         return swift


### PR DESCRIPTION
Most Swift linters expect a space between a function's `:` and the parameter/value you are passing in. The `comment` parameter was missing that space. Minor I know 🤓