### PR TITLE
Fix Build Tool Plugin Error on Xcode Cloud

### DIFF
--- a/Plugins/LingoPlugin/LingoPlugin.swift
+++ b/Plugins/LingoPlugin/LingoPlugin.swift
@@ -40,7 +40,8 @@ func lingoCommand(
 ) -> Command {
     let arguments: [String] = [
         "--input", input.string,
-        "--output", output.string
+        "--output", output.string,
+        "--non-atomic"
     ]
 
     return .buildCommand(

--- a/Plugins/LingoPlugin/LingoPlugin.swift
+++ b/Plugins/LingoPlugin/LingoPlugin.swift
@@ -68,7 +68,7 @@ struct LingoPlugin: BuildToolPlugin {
         }
 
         let outputFile = context.pluginWorkDirectory
-            .appending([Constants.outputFile, Constants.outputFile])
+            .appending([Constants.outputDirectory, Constants.outputFile])
 
         let lingo = try context.tool(named: "Lingo")
         return [lingoCommand(lingo, input: inputFile, output: outputFile)]
@@ -92,7 +92,7 @@ extension LingoPlugin: XcodeBuildToolPlugin {
         }
 
         let outputFile = context.pluginWorkDirectory
-            .appending([Constants.outputFile, Constants.outputFile])
+            .appending([Constants.outputDirectory, Constants.outputFile])
 
         let lingo = try context.tool(named: "Lingo")
         return [lingoCommand(lingo, input: inputFile, output: outputFile)]

--- a/Sources/Lingo/Lingo.swift
+++ b/Sources/Lingo/Lingo.swift
@@ -49,8 +49,13 @@ struct Lingo: ParsableCommand {
     )
     var packageName: String?
 
+    @Flag(help: ArgumentHelp(
+        "Write the generated file non-atomically.",
+        discussion: "This is offered as a workaround for a permissions issue that prevents the build tool plugin from working on Xcode Cloud when writing atomically."))
+    var nonAtomic = false
+
     /// Runs the Lingo command line tool.
     func run() throws {
-        try LingoCore.run(input: input, output: output, packageName: packageName)
+        try LingoCore.run(input: input, output: output, packageName: packageName, writeAtomically: !nonAtomic)
     }
 }

--- a/Sources/Lingo/Lingo.swift
+++ b/Sources/Lingo/Lingo.swift
@@ -35,10 +35,10 @@ struct Lingo: ParsableCommand {
         abstract: "Swift code generation for Localizable.strings files",
         version: Version.number)
 
-    @Option(help: "path to Localizable.strings file")
+    @Option(help: "Path to Localizable.strings file.")
     var input: String
 
-    @Option(help: "path including file name to write Swift to")
+    @Option(help: "Path including file name to write Swift to.")
     var output: String
 
     @Option(

--- a/Sources/LingoCore/FileHandler.swift
+++ b/Sources/LingoCore/FileHandler.swift
@@ -44,7 +44,7 @@ struct FileHandler {
 
     static func writeOutput(swift: String, to outputPath: String) throws {
         let doWrite = {
-            try swift.write(toFile: outputPath, atomically: true, encoding: .utf8)
+            try swift.write(toFile: outputPath, atomically: false, encoding: .utf8)
         }
 
         if let existingSwift = try? String(contentsOfFile: outputPath)  {

--- a/Sources/LingoCore/FileHandler.swift
+++ b/Sources/LingoCore/FileHandler.swift
@@ -42,9 +42,9 @@ struct FileHandler {
         }
     }
 
-    static func writeOutput(swift: String, to outputPath: String) throws {
+    static func writeOutput(swift: String, to outputPath: String, atomically: Bool = true) throws {
         let doWrite = {
-            try swift.write(toFile: outputPath, atomically: false, encoding: .utf8)
+            try swift.write(toFile: outputPath, atomically: atomically, encoding: .utf8)
         }
 
         if let existingSwift = try? String(contentsOfFile: outputPath)  {

--- a/Sources/LingoCore/LingoCore.swift
+++ b/Sources/LingoCore/LingoCore.swift
@@ -35,7 +35,16 @@ public struct LingoCore {
     ///  - input: The path to the Localizable.strings file.
     ///  - output: The path to write the generated Swift file to.
     ///  - packageName: The name of the SPM package which `Lingo.swift` will belong to.
-    public static func run(input: String, output: String, packageName: String?) throws {
+    ///  - writeAtomically: If `true`, the generated Swift file is first written to an auxiliary
+    ///  file, and then the auxiliary file is renamed to `output`. The `true` option guarantees that
+    ///  `output`, if it exists at all, won’t be corrupted even if the system should crash during 
+    ///  writing.
+    public static func run(
+        input: String,
+        output: String,
+        packageName: String?,
+        writeAtomically: Bool = true
+    ) throws {
         guard let fileData = FileHandler.readFiles(inputPath: input, outputPath: output) else {
             throw LingoError.custom("Couldn't read files. Did you type your arguments incorrectly?")
         }
@@ -44,6 +53,6 @@ public struct LingoCore {
         let generatedStructs = StructGenerator.generate(keyValues: keyValues)
         let swift = SwiftGenerator.generate(structs: generatedStructs, keyValues: keyValues, packageName: packageName)
 
-        try FileHandler.writeOutput(swift: swift, to: output)
+        try FileHandler.writeOutput(swift: swift, to: output, atomically: writeAtomically)
     }
 }


### PR DESCRIPTION
Fixes an error on Xcode Cloud when using the build tool plugin by adding a `--non-atomic` flag that the build tool plugin uses. This causes Lingo to write the output file non-atomically, avoiding an initial write to an auxilary file in a directory to which Xcode Cloud does not grant write permissions.

This also fixes a mistake in the plugin's output file path, changing it from `.../LingoPlugin/Lingo.swift/Lingo.swift` to `.../LingoPlugin/GeneratedSources/Lingo.swift`