### PR TITLE
Fix Action Failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  workflow_call:
   push:
     branches: [ main ]
     paths:


### PR DESCRIPTION
There was an error evaluating the Create Release workflow:

```
error parsing called workflow
".github/workflows/create-release.yml"
-> "Mobelux/Lingo/.github/workflows/test.yml@main" (source branch with sha:439bfdc78e5b9c5c26b4477c158e70f20ff63611)
: workflow is not reusable as it is missing a `on.workflow_call` trigger
```

This fixes that by adding a `workflow_call` trigger to make the test workflow reusable.