### PR TITLE
Fix Preview Crash with Xcode 16

### DIFF
--- a/Sources/LingoCore/SwiftGenerator.swift
+++ b/Sources/LingoCore/SwiftGenerator.swift
@@ -77,7 +77,19 @@ public struct SwiftGenerator {
         if let packageName = packageName {
             return """
             let bundleName = "\(packageName)_\(packageName)"
-                        let candidates = [
+                        let overrides: [URL]
+                        #if DEBUG
+                        if let override = ProcessInfo.processInfo.environment["PACKAGE_RESOURCE_BUNDLE_PATH"]
+                                       ?? ProcessInfo.processInfo.environment["PACKAGE_RESOURCE_BUNDLE_URL"] {
+                            overrides = [URL(fileURLWithPath: override)]
+                        } else {
+                            overrides = []
+                        }
+                        #else
+                        overrides = []
+                        #endif
+            
+                        let candidates = overrides + [
                             /* Bundle should be present here when the package is linked into an App. */
                             Bundle.main.resourceURL,
                             /* Bundle should be present here when the package is linked into a framework. */


### PR DESCRIPTION
Xcode 16 has apparently the changed the paths that are used when running preview from a different package, causing fatal errors.

It would seem that the path to `.../Debug-iphonesimulator/` is no longer given by `Bundle(for: BundleLocator.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()`. In my testing, with previews in Xcode 16.0, that provided a path that looks like:

```
.../Xcode/UserData/Previews/Simulator%20Devices/.../data/Containers/Bundle/Application/
```

Instead, the correct path was given by either the environment variable `PACKAGE_RESOURCE_BUNDLE_PATH` or `PACKAGE_RESOURCE_BUNDLE_URL`, and looks like:

```
.../Xcode/DerivedData/Decks-iOS-.../Build/Products/Debug-iphonesimulator/
```

This copies the relevant code from the generated `resource_bundle_accessor.swift` file in which `Bundle.module` is defined. 

An alternative approach would be to simply return `Bundle.module` if a `Bundle` instance cannot be created from the candidate `URL`s instead of calling `fatalError(_:)`, but I thought this was more consistent with the current implementation.