### PR TITLE
Add Tests for CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   workflow_call:
+  workflow_dispatch:
   push:
     branches: [ main ]
     paths:

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
             name: "LingoCore",
             dependencies: []),
         .testTarget(
-            name: "LingoTests",
+            name: "CoreTests",
             dependencies: ["LingoCore"]),
         .plugin(
             name: "LingoPlugin",

--- a/Package.swift
+++ b/Package.swift
@@ -19,17 +19,22 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "Lingo",
-            dependencies: ["LingoCore",
-                           .product(name: "ArgumentParser", package: "swift-argument-parser")]),
+            dependencies: [
+                "LingoCore",
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ]),
         .target(
             name: "LingoCore",
             dependencies: []),
-        .testTarget(
-            name: "CoreTests",
-            dependencies: ["LingoCore"]),
         .plugin(
             name: "LingoPlugin",
             capability: .buildTool(),
+            dependencies: ["Lingo"]),
+        .testTarget(
+            name: "CoreTests",
+            dependencies: ["LingoCore"]),
+        .testTarget(
+            name: "LingoTests",
             dependencies: ["Lingo"])
     ]
 )

--- a/Tests/CoreTests/CoreTests.swift
+++ b/Tests/CoreTests/CoreTests.swift
@@ -1,5 +1,5 @@
 //
-//  LingoTests.swift
+//  CoreTests.swift
 //  LingoTests
 //
 //  MIT License
@@ -28,7 +28,7 @@
 import XCTest
 @testable import LingoCore
 
-class LingoTests: XCTestCase {
+class CoreTests: XCTestCase {
     let outputURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("output.swift")
 
     override func tearDown() {
@@ -79,11 +79,11 @@ class LingoTests: XCTestCase {
         let structs = StructGenerator.generate(keyValues: keyValues)
         let swift = SwiftGenerator.generate(structs: structs, keyValues: keyValues, packageName: nil)
 
-        XCTAssert(swift == LingoTests.expectedText, "Generated Swift doesn't match expected")
+        XCTAssert(swift == CoreTests.expectedText, "Generated Swift doesn't match expected")
     }
 
     func testLocalizedStringParsing() {
-        let strings = LingoTests.localizableStrings
+        let strings = CoreTests.localizableStrings
 
         let keys = Array(KeyGenerator.generate(localizationFileContents: strings).keys).sorted()
 
@@ -96,23 +96,23 @@ class LingoTests: XCTestCase {
 
     func testFileHandling() {
         do {
-            let inputURL = try LingoTests.write(LingoTests.localizableStrings, toTemp: "input")
+            let inputURL = try CoreTests.write(CoreTests.localizableStrings, toTemp: "input")
             let fileData = FileHandler.readFiles(inputPath: inputURL.path, outputPath: outputURL.path)
             XCTAssertNotNil(fileData, "Couldn't read files")
 
-            try FileHandler.writeOutput(swift: LingoTests.expectedText, to: outputURL.path)
+            try FileHandler.writeOutput(swift: CoreTests.expectedText, to: outputURL.path)
         } catch let error {
             XCTAssert(false, error.localizedDescription)
         }
     }
 
     func testEverything() {
-        let url = try! LingoTests.write(LingoTests.localizableStrings, toTemp: "input")
+        let url = try! CoreTests.write(CoreTests.localizableStrings, toTemp: "input")
         measure {
             do {
                 try LingoCore.run(input: url.path, output: outputURL.path, packageName: nil)
 
-                let expectedSwift = LingoTests.expectedText
+                let expectedSwift = CoreTests.expectedText
                 let generatedSwift = try? String(contentsOf: self.outputURL)
                 XCTAssertNotNil(generatedSwift, "Didn't generate Swift")
                 if let generatedSwift = generatedSwift {
@@ -125,7 +125,7 @@ class LingoTests: XCTestCase {
     }
 }
 
-private extension LingoTests {
+private extension CoreTests {
     static func write(_ text: String, toTemp fileName: String) throws -> URL {
         let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
         try text.write(to: url, atomically: true, encoding: .utf8)

--- a/Tests/LingoTests/LingoTests.swift
+++ b/Tests/LingoTests/LingoTests.swift
@@ -24,7 +24,6 @@
 //  THE SOFTWARE.
 //
 
-@testable import lingo
 import ArgumentParser
 import XCTest
 

--- a/Tests/LingoTests/LingoTests.swift
+++ b/Tests/LingoTests/LingoTests.swift
@@ -38,6 +38,11 @@ class LingoTests: XCTestCase {
         let command = "lingo --input \(inputURL.path()) --output \(outputURL.path()) --package-name Localization"
         try AssertExecuteCommand(command: command)
     }
+
+    func testMissingOptionsFail() throws {
+        let command = "lingo --package-name Localization"
+        try AssertExecuteCommand(command: command, exitCode: ExitCode(64))
+    }
 }
 
 private extension LingoTests {

--- a/Tests/LingoTests/LingoTests.swift
+++ b/Tests/LingoTests/LingoTests.swift
@@ -1,0 +1,51 @@
+//
+//  LingoTests.swift
+//
+//  MIT License
+//
+//  Copyright (c) 2024 Mobelux
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+@testable import lingo
+import ArgumentParser
+import XCTest
+
+class LingoTests: XCTestCase {
+    static let localizableStrings = """
+        "Lingo.WasHisName" = "Oh";
+        """
+
+    func testCLI() throws {
+        let inputURL = try Self.write(Self.localizableStrings, toTemp: "Localizable.strings")
+        let outputURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("Lingo.swift")
+        let command = "lingo --input \(inputURL.path()) --output \(outputURL.path()) --package-name Localization"
+        try AssertExecuteCommand(command: command)
+    }
+}
+
+private extension LingoTests {
+    static func write(_ text: String, toTemp fileName: String) throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
+        try text.write(to: url, atomically: true, encoding: .utf8)
+
+        return url
+    }
+}

--- a/Tests/LingoTests/XCTest+Utils.swift
+++ b/Tests/LingoTests/XCTest+Utils.swift
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Argument Parser open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Foundation
+import XCTest
+
+extension XCTest {
+    var debugURL: URL {
+        let bundleURL = Bundle(for: type(of: self)).bundleURL
+        return bundleURL.lastPathComponent.hasSuffix("xctest")
+        ? bundleURL.deletingLastPathComponent()
+        : bundleURL
+    }
+
+    func AssertExecuteCommand(
+        command: String,
+        expected: String? = nil,
+        exitCode: ExitCode = .success,
+        file: StaticString = #file, line: UInt = #line
+    ) throws {
+        let splitCommand = command.split(separator: " ")
+        let arguments = splitCommand.dropFirst().map(String.init)
+
+        let commandName = String(splitCommand.first!)
+        let commandURL = debugURL.appendingPathComponent(commandName)
+        guard (try? commandURL.checkResourceIsReachable()) ?? false else {
+            XCTFail("No executable at '\(commandURL.standardizedFileURL.path)'.",
+                    file: (file), line: line)
+            return
+        }
+
+        #if !canImport(Darwin) || os(macOS)
+        let process = Process()
+        if #available(macOS 10.13, *) {
+            process.executableURL = commandURL
+        } else {
+            process.launchPath = commandURL.path
+        }
+        process.arguments = arguments
+
+        let output = Pipe()
+        process.standardOutput = output
+        let error = Pipe()
+        process.standardError = error
+
+        guard (try? process.run()) != nil else {
+            XCTFail("Couldn't run command process.", file: (file), line: line)
+            return
+        }
+
+        process.waitUntilExit()
+
+        let outputData = output.fileHandleForReading.readDataToEndOfFile()
+        let outputActual = String(data: outputData, encoding: .utf8)!.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let errorData = error.fileHandleForReading.readDataToEndOfFile()
+        let errorActual = String(data: errorData, encoding: .utf8)!.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let expected = expected {
+            AssertEqualStringsIgnoringTrailingWhitespace(expected, errorActual + outputActual, file: file, line: line)
+        }
+
+        XCTAssertEqual(process.terminationStatus, exitCode.rawValue, file: (file), line: line)
+        #else
+        throw XCTSkip("Not supported on this platform")
+        #endif
+    }
+}
+
+extension Substring {
+    func trimmed() -> Substring {
+        guard let i = lastIndex(where: { $0 != " "}) else {
+            return ""
+        }
+        return self[...i]
+    }
+}
+
+func AssertEqualStringsIgnoringTrailingWhitespace(
+    _ string1: String,
+    _ string2: String,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    let lines1 = string1.split(separator: "\n", omittingEmptySubsequences: false)
+    let lines2 = string2.split(separator: "\n", omittingEmptySubsequences: false)
+
+    XCTAssertEqual(lines1.count, lines2.count, "Strings have different numbers of lines.", file: (file), line: line)
+    for (line1, line2) in zip(lines1, lines2) {
+        XCTAssertEqual(line1.trimmed(), line2.trimmed(), file: (file), line: line)
+    }
+}

--- a/Tests/LingoTests/XCTestManifests.swift
+++ b/Tests/LingoTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !os(macOS)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(LingoTests.allTests),
-    ]
-}
-#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import LingoTests
-
-var tests = [XCTestCaseEntry]()
-tests += LingoTests.allTests()
-XCTMain(tests)


### PR DESCRIPTION
Adds tests for CLI execution so we can be sure that dependabot updates don't cause any problems.

- Renames `LingoTests` -> `CoreTests`
- Adds `LingoTests` to test command execution. This uses some helpers from Swift Argument Parser's `ArgumentParserTestHelpers` target.
- Removes old test support files

Additional:

- Adds manual trigger for test workflow